### PR TITLE
Change parameter input to findBy

### DIFF
--- a/functions/tickle-bot/src/queries/communityStats.js
+++ b/functions/tickle-bot/src/queries/communityStats.js
@@ -2,7 +2,7 @@ export default {
   graphQl: `
     query getCommunityStats($communityInput: CommunityQueryInput!) {
       communities {
-        community(input: $communityInput) {
+        community(findBy: $communityInput) {
           stats {
             totalMembers
             totalActivities

--- a/functions/tickle-bot/src/queries/slackDigest.js
+++ b/functions/tickle-bot/src/queries/slackDigest.js
@@ -2,7 +2,7 @@ export default {
   graphQl: `
     query invokeSlackDigest($communityInput: CommunityQueryInput!, $hours: Int!, $start: DigestStart) {
       communities {
-        community(input: $communityInput) {
+        community(findBy: $communityInput) {
           sendDigest(hours: $hours, start: $start) {
             id
             title


### PR DESCRIPTION
Fixes parameter change in api from using `input` to `findBy`