### PR TITLE
brinks: add allocation of membership to non-bulk orders.

### DIFF
--- a/functions/brinks/src/constants.js
+++ b/functions/brinks/src/constants.js
@@ -1,25 +1,25 @@
-const constants = () => ({
-  that: {
-    productType: {
-      ticket: 'TICKET',
-      membership: 'MEMBERSHIP',
-      partnership: 'PARTNERSHIP',
-      food: 'FOOD',
+const constants = {
+  THAT: {
+    PRODUCT_TYPE: {
+      TICKET: 'TICKET',
+      MEMBERSHIP: 'MEMBERSHIP',
+      PARTNERSHIP: 'PARTNERSHIP',
+      FOOD: 'FOOD',
     },
   },
-  stripe: {
-    checkoutMode: {
-      payment: 'payment',
-      subscription: 'subscription',
+  STRIPE: {
+    CHECKOUT_MODE: {
+      PAYMENT: 'payment',
+      SUBSCRIPTION: 'subscription',
     },
-    subscriptionStatus: {
-      active: 'active',
-      cancelled: 'canceled',
-      pastDue: 'past_due',
-      unpaid: 'unpaid',
-      incomplete: 'incomplete',
-      incompleteExpired: 'incomplete_expried',
+    SUBSCRIPTION_STATUS: {
+      ACTIVE: 'active',
+      CANCELLED: 'canceled',
+      PAST_DUE: 'past_due',
+      UNPAID: 'unpaid',
+      INCOMPLETE: 'incomplete',
+      INCOMPLETE_EXPIRED: 'incomplete_expired',
     },
   },
-});
-export default constants();
+};
+export default constants;

--- a/functions/brinks/src/constants.js
+++ b/functions/brinks/src/constants.js
@@ -1,0 +1,25 @@
+const constants = () => ({
+  that: {
+    productType: {
+      ticket: 'TICKET',
+      membership: 'MEMBERSHIP',
+      partnership: 'PARTNERSHIP',
+      food: 'FOOD',
+    },
+  },
+  stripe: {
+    checkoutMode: {
+      payment: 'payment',
+      subscription: 'subscription',
+    },
+    subscriptionStatus: {
+      active: 'active',
+      cancelled: 'canceled',
+      pastDue: 'past_due',
+      unpaid: 'unpaid',
+      incomplete: 'incomplete',
+      incompleteExpired: 'incomplete_expried',
+    },
+  },
+});
+export default constants();

--- a/functions/brinks/src/dataSources/cloudFirestore/order.js
+++ b/functions/brinks/src/dataSources/cloudFirestore/order.js
@@ -18,7 +18,7 @@ const order = dbInstance => {
       .get()
       .then(docSnapshot => {
         let result = null;
-        if (docSnapshot.size > 0) result = docSnapshot.doc[0].id;
+        if (docSnapshot.size > 0) result = docSnapshot.docs[0].id;
 
         return result;
       });

--- a/functions/brinks/src/envConfig.js
+++ b/functions/brinks/src/envConfig.js
@@ -16,6 +16,11 @@ const requiredConfig = () => ({
       process.env.MESSAGE_TOPIC_STRIPE_EVENTS ||
       configMissing('MESSAGE_TOPIC_STRIPE_EVENTS'),
   },
+  that: {
+    systemUpdatedBy:
+      process.env.THAT_SYSTEM_UPDATED_BY ||
+      configMissing('THAT_SYSTEM_UPDATED_BY'),
+  },
 });
 
 export default requiredConfig();

--- a/functions/brinks/src/lib/applyMembershipAllocationsToMembers.js
+++ b/functions/brinks/src/lib/applyMembershipAllocationsToMembers.js
@@ -20,7 +20,7 @@ export default async function applyMembershipAllocationsToMembers({
     a =>
       a.isAllocated &&
       a.allocatedTo &&
-      a.productType === constants.that.productType.membership,
+      a.productType === constants.THAT.PRODUCT_TYPE.MEMBERSHIP,
   );
   if (applyAllocations < 1) {
     dlog('no allocations are allocated, nothing to do, leaving');
@@ -35,7 +35,7 @@ export default async function applyMembershipAllocationsToMembers({
   const baseMemberUpdate = {
     stripeSubscriptionId: stripeSubscription.id,
     isMember:
-      stripeSubscription.status === constants.stripe.subscriptionStatus.active,
+      stripeSubscription.status === constants.STRIPE.SUBSCRIPTION_STATUS.ACTIVE,
     membershipExpirationDate: new Date(
       stripeSubscription.current_period_end * 1000,
     ),

--- a/functions/brinks/src/lib/applyMembershipAllocationsToMembers.js
+++ b/functions/brinks/src/lib/applyMembershipAllocationsToMembers.js
@@ -1,0 +1,69 @@
+// For a provided order, and allocations apply them to the members
+// they are allocated to.
+import debug from 'debug';
+import { dataSources } from '@thatconference/api';
+import getStripeSubscription from './stripe/getStripeSubscription';
+import envConfig from '../envConfig';
+import constants from '../constants';
+
+const dlog = debug('that:api:functions:brinks:applyAllocationsToMembers');
+const memberStore = dataSources.cloudFirestore.member;
+
+export default async function applyMembershipAllocationsToMembers({
+  order,
+  allocations,
+  firestore,
+}) {
+  dlog('applyAllocationToMembers called for order id: %s', order.id);
+
+  const applyAllocations = allocations.filter(
+    a =>
+      a.isAllocated &&
+      a.allocatedTo &&
+      a.productType === constants.that.productType.membership,
+  );
+  if (applyAllocations < 1) {
+    dlog('no allocations are allocated, nothing to do, leaving');
+    // return Promise.resolve();
+    return [];
+  }
+
+  const stripeSubscription = await getStripeSubscription(
+    order.stripeSubscriptionId,
+  );
+
+  const baseMemberUpdate = {
+    stripeSubscriptionId: stripeSubscription.id,
+    isMember:
+      stripeSubscription.status === constants.stripe.subscriptionStatus.active,
+    membershipExpirationDate: new Date(
+      stripeSubscription.current_period_end * 1000,
+    ),
+    stripeSubscriptionCancelAtExpiration:
+      stripeSubscription.cancel_at_period_end,
+    lastUpdatedBy: envConfig.that.systemUpdatedBy,
+    lastUpdatedAt: new Date(),
+  };
+
+  const memberUpdates = applyAllocations.map(allocation => {
+    const memberUpdate = {
+      ...baseMemberUpdate,
+    };
+
+    return {
+      [allocation.allocatedTo]: memberUpdate,
+    };
+  });
+
+  // write updatest to member(s)
+  const updateFuncs = memberUpdates.map(mu => {
+    const [key] = Object.keys(mu);
+    return memberStore(firestore).update({
+      memberId: key,
+      profile: mu[key],
+    });
+  });
+  dlog('update functions:: %o', updateFuncs);
+
+  return Promise.all(updateFuncs);
+}

--- a/functions/brinks/src/lib/createOrderFromCheckout.js
+++ b/functions/brinks/src/lib/createOrderFromCheckout.js
@@ -30,6 +30,7 @@ export default function createOrderFromCheckout({ checkoutSession, products }) {
       totalAmount: stripeLi.amount_total / 100,
       stripeProductId: stripeLi.price.product,
       isBulkPurchase: coLineItem.isBulkPurchase,
+      productType: product.type,
     };
   });
 
@@ -52,7 +53,7 @@ export default function createOrderFromCheckout({ checkoutSession, products }) {
     stripePaymentIntentId: checkoutSession.payment_intent,
     stripeCheckoutSessionId: checkoutSession.id,
     stripeMode: checkoutSession.mode,
-    stripeSubscription: checkoutSession.subscription,
+    stripeSubscriptionId: checkoutSession.subscription,
     stripeLivemode: checkoutSession.livemode,
     total: checkoutSession.amount_total / 100,
     amountDiscounted: checkoutSession.total_details.amount_discount,

--- a/functions/brinks/src/lib/generateAllocationsFromOrder.js
+++ b/functions/brinks/src/lib/generateAllocationsFromOrder.js
@@ -15,13 +15,14 @@ export default function generateAllocationsFromOrder({
   lineItems.forEach(lineItem => {
     const qty = lineItem.quantity;
     const { isBulkPurchase } = lineItem;
-    dlog(`line item isBulkPurchase: ${isBulkPurchase}`);
+    dlog(`line item isBulkPurchase: %s, qty: %d`, isBulkPurchase, qty);
     for (let i = 0; i < qty; i += 1) {
       // note, we don't have an order id yet
       const allocation = {
         event: order.event,
         purchasedBy: order.member,
         product: lineItem.product,
+        productType: lineItem.productType,
         isAllocated: !isBulkPurchase,
         allocatedTo: isBulkPurchase ? null : order.member,
         hasCheckedIn: false,

--- a/functions/brinks/src/lib/stripe/getStripeSubscription.js
+++ b/functions/brinks/src/lib/stripe/getStripeSubscription.js
@@ -1,0 +1,11 @@
+import debug from 'debug';
+import stripelib from 'stripe';
+import envConfig from '../../envConfig';
+
+const dlog = debug('that:api:functions:brinks:getStripeSubscription');
+const stripe = stripelib(envConfig.stripe.apiSecretKey);
+
+export default function getStripeSubscription(subscriptionId) {
+  dlog('getStripeSubscriptiong called for %s', subscriptionId);
+  return stripe.subscriptions.retrieve(subscriptionId);
+}


### PR DESCRIPTION
Stripe orders using checkout will auto-allocate a non-bulk membership purchase to the member who created the order. 
If the member orders another membership through checkout (not renewing the current one) it will overwrite their member record with the new membership data. Both memberships will be displayed under their customer account in stripe.