### PR TITLE
Save promo code id for lookup reference

### DIFF
--- a/functions/brinks/src/constants.js
+++ b/functions/brinks/src/constants.js
@@ -18,7 +18,7 @@ constants.THAT.DISCOUNT_CODE = {
 // Hey you found the codes, use hAckEr12 for 12% off instead!!!
 constants.THAT.PROMO_CODE = {
   MEMBERSHIP_STORE_DISCOUNT: {
-    TITLE: 'Membership THAT Store discount 10%',
+    TITLE: 'Membership THAT Store Discount 10%',
     CODE: 'THATMembership2021',
     EXPIRE_IN_DAYS: 1825,
   },

--- a/functions/brinks/src/lib/applyMembershipAllocationsToMembers.js
+++ b/functions/brinks/src/lib/applyMembershipAllocationsToMembers.js
@@ -44,7 +44,8 @@ export default async function applyMembershipAllocationsToMembers({
     },
   });
   const membershipCamperDiscountCode = {
-    code: camperDiscountCode,
+    code: camperDiscountCode.code,
+    promoCodeId: camperDiscountCode.promoCodeId,
     title: 'Membership Camper Discount',
     type: constants.THAT.DISCOUNT_CODE.TYPE.TICKET,
     expiresAt: new Date(stripeSubscription.current_period_end * 1000),

--- a/functions/brinks/src/lib/stripe/createPromotionCode.js
+++ b/functions/brinks/src/lib/stripe/createPromotionCode.js
@@ -24,5 +24,7 @@ export default function createPromotionCode({
   };
 
   // Returns new promotion code value (string) just created)
-  return stripe.promotionCodes.create(payload).then(r => r.code);
+  return stripe.promotionCodes
+    .create(payload)
+    .then(r => ({ code: r.code, promoCodeId: r.id }));
 }


### PR DESCRIPTION
There is no way to lookup a promotion `code` in the stripe dashboard, only the id's can be searched for. Because of this we'll save the id along side the code in case we needed it for researching orders, etc. 

fixed a type in a discount code's title in constants. 