### PR TITLE
Fix issue where uiReference no set on membership-type product

### DIFF
--- a/functions/brinks/package.json
+++ b/functions/brinks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brinks",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Our order taker",
   "main": "index.js",
   "scripts": {

--- a/functions/brinks/src/lib/generateAllocationsFromOrder.js
+++ b/functions/brinks/src/lib/generateAllocationsFromOrder.js
@@ -23,7 +23,7 @@ export default function generateAllocationsFromOrder({
         purchasedBy: order.member,
         product: lineItem.product,
         productType: lineItem.productType,
-        uiReference: lineItem.uiReference,
+        uiReference: lineItem.uiReference || null,
         isAllocated: !isBulkPurchase,
         allocatedTo: isBulkPurchase ? null : order.member,
         hasCheckedIn: false,


### PR DESCRIPTION
Memberships don't have or need a ui reference at this time and the value is set to `null` in the database. This value was being set as `undefined` when an order was being created into firestore. Firestore doesn't allow an `undefined` value to be stored, it must be set to `null`.