### PR TITLE
updates action version reference and gcloud used version

### DIFF
--- a/.github/workflows/bouncer_PushMaster.yml
+++ b/.github/workflows/bouncer_PushMaster.yml
@@ -60,9 +60,9 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file

--- a/.github/workflows/brinks_PushMaster.yml
+++ b/.github/workflows/brinks_PushMaster.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}

--- a/.github/workflows/fileUpload_PushMaster.yml
+++ b/.github/workflows/fileUpload_PushMaster.yml
@@ -60,9 +60,9 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file

--- a/.github/workflows/newman_PushMaster.yml
+++ b/.github/workflows/newman_PushMaster.yml
@@ -60,9 +60,9 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file

--- a/.github/workflows/that-api-og-image_PushMaster.yml
+++ b/.github/workflows/that-api-og-image_PushMaster.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}

--- a/.github/workflows/that-api-webhooks_PushMaster.yml
+++ b/.github/workflows/that-api-webhooks_PushMaster.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file

--- a/.github/workflows/tickle-bot_PushMaster.yml
+++ b/.github/workflows/tickle-bot_PushMaster.yml
@@ -60,9 +60,9 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file

--- a/.github/workflows/voting-on-create_PushMaster.yml
+++ b/.github/workflows/voting-on-create_PushMaster.yml
@@ -58,9 +58,9 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file

--- a/.github/workflows/voting-on-delete_PushMaster.yml
+++ b/.github/workflows/voting-on-delete_PushMaster.yml
@@ -58,9 +58,9 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file

--- a/.github/workflows/voting-on-update_PushMaster.yml
+++ b/.github/workflows/voting-on-update_PushMaster.yml
@@ -58,9 +58,9 @@ jobs:
         with:
           name: tc-api
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          version: '356.0.0'
+          version: '360.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file


### PR DESCRIPTION
Updates GitHub actions for all functions.
Changes `google-github-actions/setup-gcloud@master` to `google-github-actions/setup-gcloud@v0` per recommendations
Changes gcloud version to `360.0.0`

This merge will not trigger any builds or deploys as the action files are outside of the triggered path in the functions macro repo. 