### PR TITLE
fix naming on deploy job. Add readme details. Fix test

### DIFF
--- a/.github/workflows/tickle-bot_PushMaster.yml
+++ b/.github/workflows/tickle-bot_PushMaster.yml
@@ -51,7 +51,7 @@ jobs:
         if: job.status == 'failure' || job.status == 'cancelled'
 
   deploy-image:
-    name: Deploy Image Upload
+    name: Deploy Ticklebot
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/functions/tickle-bot/package.json
+++ b/functions/tickle-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tickle-bot",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Provides authenticated requests against our api",
   "main": "index.js",
   "scripts": {

--- a/functions/tickle-bot/readme.md
+++ b/functions/tickle-bot/readme.md
@@ -3,3 +3,9 @@
 Got to love the name... well maybe not.
 
 This function is used to make authenticated api calls against the THAT api.
+
+## info
+
+Deployed as a Google Cloud Function
+
+Current runtime nodejs 16.x

--- a/functions/tickle-bot/src/lib/__tests__/createBatchesFromCollection.test.js
+++ b/functions/tickle-bot/src/lib/__tests__/createBatchesFromCollection.test.js
@@ -169,7 +169,7 @@ describe(`validate createBatchesFromCollection() operation`, () => {
         acc.push(...cur);
         return acc;
       }, []);
-      ids.forEach((id, idx) => expect(id === ids[idx]));
+      ids.forEach((id, idx) => expect(id === all[idx]));
     });
   });
 });


### PR DESCRIPTION
v2.0.1
Deploy issue was actually due to secrets not updated. 
These are more "clean-up" type updates. 