### PR TITLE
Fixes issue where full member object not passed into event on manual orders

### DIFF
--- a/functions/brinks/package.json
+++ b/functions/brinks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brinks",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Our order taker",
   "main": "index.js",
   "scripts": {

--- a/functions/brinks/src/lib/that/createOrderAndAllocations.js
+++ b/functions/brinks/src/lib/that/createOrderAndAllocations.js
@@ -47,6 +47,7 @@ export default function createOrderAndAllocations({
     orderType: orderData.orderType ?? 'REGULAR',
     discounts: discount ? [discount] : [],
   };
+  delete newOrder.discount;
 
   const orderAllocations = generateAllocationsFromOrder({
     order: newOrder,


### PR DESCRIPTION
v1.15.1

Event functions under the new order event emitter would fail when called from manual orders.
A member object was not being presented to the emitter.