### PR TITLE
BRINKS: Fix bug when there are no discounts

### DIFF
--- a/functions/brinks/package-lock.json
+++ b/functions/brinks/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brinks",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "brinks",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@google-cloud/firestore": "^6.3.0",

--- a/functions/brinks/package.json
+++ b/functions/brinks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brinks",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Our order taker",
   "main": "index.js",
   "scripts": {

--- a/functions/brinks/src/lib/createOrderFromCheckout.js
+++ b/functions/brinks/src/lib/createOrderFromCheckout.js
@@ -40,12 +40,12 @@ export default function createOrderFromCheckout({ checkoutSession, products }) {
   const { breakdown } = checkoutSession.total_details;
   const discounts = Array.isArray(breakdown?.discounts)
     ? breakdown.discounts.map(d => ({
-        amount: d.amount,
-        promotionCode: d.discount.promotion_code,
-        name: d.discount.coupon.name,
-        amountOff: d.discount.coupon.amount_off,
-        percentOff: d.discount.coupon.percent_off,
-        couponId: d.discount.coupon.id,
+        amount: d?.amount,
+        promotionCode: d?.discount?.promotion_code,
+        name: d?.discount?.coupon.name,
+        amountOff: d?.discount?.coupon.amount_off,
+        percentOff: d?.discount?.coupon?.percent_off,
+        couponId: d?.discount?.coupon?.id,
       }))
     : [];
 
@@ -70,7 +70,7 @@ export default function createOrderFromCheckout({ checkoutSession, products }) {
     status: 'COMPLETE',
     orderType: 'REGULAR',
     affiliateCode: checkoutSession?.metadata?.affiliateCode ?? null,
-    includesPromotionCodes: discounts.map(d => d.promotionCode),
+    includesPromotionCodes: discounts.map(d => d?.promotionCode),
     includesProducts: [...new Set(lineItems.map(li => li.product))],
     includesProductTypes: [...new Set(lineItems.map(li => li.productType))],
     includesStripeProducts: [

--- a/functions/brinks/src/lib/that/createOrderAndAllocations.js
+++ b/functions/brinks/src/lib/that/createOrderAndAllocations.js
@@ -46,8 +46,8 @@ export default function createOrderAndAllocations({
     status: orderData.status ?? 'COMPLETE',
     orderType: orderData.orderType ?? 'REGULAR',
     discounts: discount ? [discount] : [],
-    includesPromotionCodes: discount.promotionCode
-      ? [discount.promotionCode]
+    includesPromotionCodes: discount?.promotionCode
+      ? [discount?.promotionCode]
       : [],
     includesProducts: [...new Set(newLineItems.map(li => li.product))],
     includesProductTypes: [...new Set(newLineItems.map(li => li.productType))],


### PR DESCRIPTION
## BRINKS v2.4.1
Fixes bug on manual order `createOrderAndAllocations` with no promo code (undefined)
update `createOrderFromCheckout` for undefined resilience, just in case. 