### PR TITLE
feat: add canFeature and profileSlug to meet-that-camper templateModel

### DIFF
--- a/functions/tickle-bot/package.json
+++ b/functions/tickle-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tickle-bot",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Provides authenticated requests against our api",
   "main": "index.js",
   "scripts": {

--- a/functions/tickle-bot/src/lib/formatMeetThatEmails.js
+++ b/functions/tickle-bot/src/lib/formatMeetThatEmails.js
@@ -40,6 +40,8 @@ export default function formatMeetThatEmails({ newMatches }) {
     }
     const sharedProfileA = a?.allocatedTo?.profiles?.shared;
     const sharedProfileB = b?.allocatedTo?.profiles?.shared;
+    const profileA = a?.profile;
+    const profileB = b?.profile;
     if (!sharedProfileA?.email || !sharedProfileB?.email) {
       Sentry.configureScope(scope => {
         scope.tag('function', 'formatMeetThatEmails');
@@ -62,8 +64,16 @@ export default function formatMeetThatEmails({ newMatches }) {
       trackOpens: true,
       templateAlias: meetThatTemplate,
       templateModel: {
-        memberA: sharedProfileA,
-        memberB: sharedProfileB,
+        memberA: {
+          ...sharedProfileA,
+          canFeature: profileA?.canFeature ?? false,
+          profileSlug: profileA.profileSlug,
+        },
+        memberB: {
+          ...sharedProfileB,
+          canFeature: profileB?.canFeature ?? false,
+          profileSlug: profileB.profileSlug,
+        },
       },
     };
     const chkMessage = {


### PR DESCRIPTION
## Tickle-bot: v2.4.0
Add `canFeature` and `profileSlug` to engagement-meet-that-camper templateModel