### PR TITLE
ical-generator: fix: issue adding sessions to calendar with no start date

### DIFF
--- a/functions/that-api-ical-generator/package.json
+++ b/functions/that-api-ical-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-ical-generator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Generates a ical file of member's favorited sessions",
   "main": "index.js",
   "scripts": {

--- a/functions/that-api-ical-generator/src/lib/createIcs.js
+++ b/functions/that-api-ical-generator/src/lib/createIcs.js
@@ -14,22 +14,29 @@ export default ({ member, sessions }) => {
   });
 
   // event info: https://sebbo2002.github.io/ical-generator/develop/reference/interfaces/ICalEventData.html
-  const events = sessions.map(s => {
-    let location = 'ONLINE';
-    if (s.location?.location) {
-      location = s.location.location;
+  const events = [];
+  for (let i = 0; i < sessions.length; i += 1) {
+    const session = sessions[i];
+    // If there isn't a start time (date), you can't add to a calendar
+    if (dayjs(session.startTime).isValid()) {
+      let location = `See activity's details`;
+      if (session.location?.location) {
+        location = session.location.location;
+      }
+      const url = `${baseActivityUrl}/${session.id}/`;
+      events.push({
+        start: dayjs(session.startTime).toDate(),
+        end: dayjs(session.startTime)
+          .add(session.durationInMinutes, 'm')
+          .toDate(),
+        summary: session.title,
+        description: session.shortDescription,
+        location,
+        url,
+        status: 'CONFIRMED',
+      });
     }
-    const url = `${baseActivityUrl}/${s.id}/`;
-    return {
-      start: dayjs(s.startTime).toDate(),
-      end: dayjs(s.startTime).add(s.durationInMinutes, 'm').toDate(),
-      summary: s.title,
-      description: s.shortDescription,
-      location,
-      url,
-      status: 'CONFIRMED',
-    };
-  });
+  }
 
   return ical.events(events).toString();
 };


### PR DESCRIPTION
## that-api-ical-generator: v1.0.5
Fixes issue when creating a calendar entry from a session with no or invalid start date.