### PR TITLE
Tickle-bot, help-post-comment-count updates

### DIFF
--- a/.github/workflows/help-post-comment-count_PushMaster.yml
+++ b/.github/workflows/help-post-comment-count_PushMaster.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: tc-api
+          path: tc-api
       - name: Setup google auth for github actions
         uses: google-github-actions/auth@v1
         with:
@@ -90,7 +91,7 @@ jobs:
       - name: Run GCP Deploy Function - help-post-comment-count
         run: |
           cd tc-api
-          gcloud functions deploy help-post-comment-count --runtime nodejs18 --trigger-event providers/cloud.firestore/eventTypes/document.create --trigger-resource "projects/all-that/databases/(default)/documents/helpPosts/{helpPostId}/helpPostComments/{commentId}" --entry-point helpPostCommentCount
+          gcloud functions deploy help-post-comment-count --runtime nodejs18 --trigger-event providers/cloud.firestore/eventTypes/document.create --trigger-resource "projects/${{ secrets.GCP_PROJECT_ID }}/databases/(default)/documents/helpPosts/{helpPostId}/helpPostComments/{commentId}" --entry-point helpPostCommentCount
         env:
           CLOUDSDK_CORE_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
       - name: Slack Notification

--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ A collection of functions used for THAT
 
 [![that-api-og-image Pull Request](https://github.com/ThatConference/that-api-functions/actions/workflows/that-api-og-image_PullRequest.yml/badge.svg)](https://github.com/ThatConference/that-api-functions/actions/workflows/that-api-og-image_PullRequest.yml)  
 [![that-api-og-image Push Master](https://github.com/ThatConference/that-api-functions/actions/workflows/that-api-og-image_PushMaster.yml/badge.svg)](https://github.com/ThatConference/that-api-functions/actions/workflows/that-api-og-image_PushMaster.yml)
+
+## [help-post-comment-count](functions/help-post-comment-count)
+
+[![help-post-comment-count Pull Request](https://github.com/ThatConference/that-api-functions/actions/workflows/help-post-comment-count_PullRequest.yml/badge.svg)](https://github.com/ThatConference/that-api-functions/actions/workflows/help-post-comment-count_PullRequest.yml)
+[![help-post-comment-count Pull Request](https://github.com/ThatConference/that-api-functions/actions/workflows/help-post-comment-count_PullRequest.yml/badge.svg)](https://github.com/ThatConference/that-api-functions/actions/workflows/help-post-comment-count_PullRequest.yml)

--- a/functions/help-post-comment-count/package.json
+++ b/functions/help-post-comment-count/package.json
@@ -1,6 +1,6 @@
 {
   "name": "help-post-comment-count",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Sets comment count on helpPost when a comment is added or removed.",
   "main": "index.js",
   "scripts": {

--- a/functions/help-post-comment-count/readme.md
+++ b/functions/help-post-comment-count/readme.md
@@ -1,0 +1,11 @@
+# THAT Functions
+
+## help-post-comment-count
+
+Firestore gcp function to update helpPost with its current comment count.
+
+The Firestore trigger activates on `write` (create, update, delete) ignoring document `update` and updating count on `create` and `delete`.
+
+### stuff
+
+nodejs 18

--- a/functions/tickle-bot/package.json
+++ b/functions/tickle-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tickle-bot",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Provides authenticated requests against our api",
   "main": "index.js",
   "scripts": {

--- a/functions/tickle-bot/src/middleware/meetThatMatching.js
+++ b/functions/tickle-bot/src/middleware/meetThatMatching.js
@@ -29,6 +29,7 @@ export default async function meetThatMatching(req, res, next) {
   const result = {
     createdAt: new Date(),
     idCountFromAllocations: 0,
+    campmateIdsFromAllocations: 0,
     optInCount: 0,
     membersToMatch: 0,
     matchesMade: 0,
@@ -86,19 +87,34 @@ export default async function meetThatMatching(req, res, next) {
   }, []);
   dlog(`combined orderAllocation count: %d`, orderAllocations.length);
   const memberIdsFromAllocations = new Map();
+  const campmateIdsFromAllocations = new Map();
   for (let i = 0; i < orderAllocations.length; i += 1) {
     const oa = orderAllocations[i];
     const allocatedTo = oa?.allocatedTo;
-    if (allocatedTo?.id) {
+    const uiReference = oa?.uiReference;
+    if (
+      allocatedTo?.id &&
+      uiReference !== 'GEEKLING' &&
+      uiReference !== 'CAMPMATE'
+    ) {
       if (!memberIdsFromAllocations.has(allocatedTo.id))
         memberIdsFromAllocations.set(allocatedTo.id, allocatedTo);
+    } else if (allocatedTo?.id && uiReference === 'CAMPMATE') {
+      // future use to send campmates engagement emails.
+      if (!campmateIdsFromAllocations.has(allocatedTo.id))
+        campmateIdsFromAllocations.set(allocatedTo.id, allocatedTo);
     }
   }
   dlog(
     'distinct member ids from allocations: %d',
     memberIdsFromAllocations.size,
   );
+  dlog(
+    'distinct campmate ids from allocations: %d',
+    campmateIdsFromAllocations.size,
+  );
   result.idCountFromAllocations = memberIdsFromAllocations.size;
+  result.campmateIdsFromAllocations = campmateIdsFromAllocations.size;
 
   let optedInMembers;
   try {

--- a/functions/tickle-bot/src/queries/oaForMemberMatching.js
+++ b/functions/tickle-bot/src/queries/oaForMemberMatching.js
@@ -18,6 +18,7 @@ export default {
               eventId
               orderAllocations(orderTypes: [REGULAR, PARTNER, SPEAKER]) {
                 id
+                uiReference
                 allocatedTo {
                   __typename
                   id


### PR DESCRIPTION
## tickle-bot: v2.5.3

fix issue where geekling and campmates could be sent an engagement email if they opted in. They are not explicitly excluded. Campmates are added to their own collection to be added to their own engagement emails in the future.

## help-post-comment-count: v1.1.0

- fix deployment artifact folder creation
- add readme
- update functions readme
