### PR TITLE
fix: guild and parent id env configuration

### DIFF
--- a/functions/that-join-discord-bot/.env.sample
+++ b/functions/that-join-discord-bot/.env.sample
@@ -17,3 +17,4 @@ APP_ID=<YOUR_APP_ID>
 DISCORD_TOKEN=<YOUR_BOT_TOKEN>
 PUBLIC_KEY=<YOUR_PUBLIC_KEY>
 GUILD_ID=<guild/server_id>
+CATEGORY_CHANNEL_ID=<where new voice channels go>

--- a/functions/that-join-discord-bot/package.json
+++ b/functions/that-join-discord-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-join-discord-bot",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "server-side functions for our v2 join discord bot",
   "main": "index.js",
   "scripts": {

--- a/functions/that-join-discord-bot/src/envConfig.js
+++ b/functions/that-join-discord-bot/src/envConfig.js
@@ -24,8 +24,9 @@ export default {
     publicKey: process.env.PUBLIC_KEY ?? configMissing('PUBLIC_KEY'),
     baseUrl: 'https://discord.com/api/v10',
     beta: {
-      guildId: '1164973641679769650',
-      categoryChannelId: '1166417863293276160',
+      guildId: process.env.GUILD_ID ?? configMissing('GUILD_ID'),
+      categoryChannelId:
+        process.env.CATEGORY_CHANNEL_ID ?? configMissing('CATEGORY_CHANNEL_ID'),
     },
   },
 };


### PR DESCRIPTION
## that-join-discord-bot

## v0.5.0

fix environment variables, correcting guild id and category channel for activity voice channels