### PR TITLE
fix channel create. Topic no longer accepted for voice channels

### DIFF
--- a/functions/that-join-discord-bot/package.json
+++ b/functions/that-join-discord-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-join-discord-bot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "server-side functions for our v2 join discord bot",
   "main": "index.js",
   "scripts": {

--- a/functions/that-join-discord-bot/src/lib/addActivityChannelAction.js
+++ b/functions/that-join-discord-bot/src/lib/addActivityChannelAction.js
@@ -77,7 +77,8 @@ export async function addChannelDetails({ activity, firestore }) {
     const vcRes = await channels.createVoiceChannel({
       guildId: discordData.guildId,
       name: title,
-      topic: shortDescription.slice(0, 1023),
+      // Voice channels no longer support topics
+      // topic: shortDescription.slice(0, 1023),
       parentId: envConfig.discord.beta.categoryChannelId,
     });
     if ([200, 201].includes(vcRes.status)) {
@@ -128,6 +129,7 @@ export async function addChannelDetails({ activity, firestore }) {
       }
     } else {
       // report failed channel creation
+      dlog('Channel create error: %o', vcRes);
       result.status = 500;
       result.message = `unable to create voice channel. Activity update not attempted`;
     }


### PR DESCRIPTION
## v0.6.1

Setting a topic on the creation of a voice channel throws a 400 error on the discord API, invalid payload