### PR TITLE
Chore/actions update node 20

### DIFF
--- a/.github/workflows/bouncer_PullRequest.yml
+++ b/.github/workflows/bouncer_PullRequest.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate

--- a/.github/workflows/bouncer_PushMaster.yml
+++ b/.github/workflows/bouncer_PushMaster.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate
@@ -36,7 +36,7 @@ jobs:
           cp ./package-lock.json __build__/
           git rev-list --count master > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/bouncer/__build__
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: tc-api
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: "437.0.1"
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/brinks_PullRequest.yml
+++ b/.github/workflows/brinks_PullRequest.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate

--- a/.github/workflows/brinks_PushMaster.yml
+++ b/.github/workflows/brinks_PushMaster.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate
@@ -36,7 +36,7 @@ jobs:
           cp ./package-lock.json __build__/
           git rev-list --count master > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/brinks/__build__
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: tc-api
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: "437.0.1"
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/fileUpload_PullRequest.yml
+++ b/.github/workflows/fileUpload_PullRequest.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate

--- a/.github/workflows/fileUpload_PushMaster.yml
+++ b/.github/workflows/fileUpload_PushMaster.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate
@@ -36,7 +36,7 @@ jobs:
           cp ./package-lock.json __build__/
           git rev-list --count master > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/fileUpload/__build__
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: tc-api
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: "437.0.1"
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/help-post-comment-count_PullRequest.yml
+++ b/.github/workflows/help-post-comment-count_PullRequest.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: npm ci, run

--- a/.github/workflows/help-post-comment-count_PushMaster.yml
+++ b/.github/workflows/help-post-comment-count_PushMaster.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: npm ci, run validate
@@ -34,7 +34,7 @@ jobs:
           cp ./package-lock.json __build__/
           git rev-list --count master > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/help-post-comment-count/__build__
@@ -55,18 +55,18 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: tc-api
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCLOUD_AUTH }}          
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup gcloud Actions CLI
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
-          version: '428.0.0'
+          version: "428.0.0"
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: write .env file
         run: |

--- a/.github/workflows/newman_PullRequest.yml
+++ b/.github/workflows/newman_PullRequest.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate

--- a/.github/workflows/newman_PushMaster.yml
+++ b/.github/workflows/newman_PushMaster.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate
@@ -36,7 +36,7 @@ jobs:
           cp ./package-lock.json __build__/
           git rev-list --count master > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/newman/__build__
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: tc-api
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: "437.0.1"
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/that-api-ical-generator_PullRequest.yml
+++ b/.github/workflows/that-api-ical-generator_PullRequest.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate

--- a/.github/workflows/that-api-ical-generator_PushMaster.yml
+++ b/.github/workflows/that-api-ical-generator_PushMaster.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
       - name: Checkout master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate
@@ -41,7 +41,7 @@ jobs:
           cp ./Dockerfile __build__/
           git rev-list --count ${{ github.ref_name }} > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/that-api-ical-generator/__build__
@@ -64,17 +64,17 @@ jobs:
       apiName: ical-generator
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: __build__
 
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup GCLOUD CLI Action
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: "437.0.1"
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/that-api-og-image_PullRequest.yml
+++ b/.github/workflows/that-api-og-image_PullRequest.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v3
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: npm ci, run validate

--- a/.github/workflows/that-api-webhooks_PullRequest.yml
+++ b/.github/workflows/that-api-webhooks_PullRequest.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run

--- a/.github/workflows/that-api-webhooks_PushMaster.yml
+++ b/.github/workflows/that-api-webhooks_PushMaster.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, lint, test
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup gcloud Actions

--- a/.github/workflows/that-join-discord-bot_PullRequest copy.yml
+++ b/.github/workflows/that-join-discord-bot_PullRequest copy.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate

--- a/.github/workflows/that-join-discord-bot_PushMaster copy.yml
+++ b/.github/workflows/that-join-discord-bot_PushMaster copy.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate
@@ -36,7 +36,7 @@ jobs:
           cp ./package-lock.json __build__/
           git rev-list --count master > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/that-join-discord-bot/__build__
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: tc-api
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: "437.0.1"
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/tickle-bot_PullRequest.yml
+++ b/.github/workflows/tickle-bot_PullRequest.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate

--- a/.github/workflows/tickle-bot_PushMaster.yml
+++ b/.github/workflows/tickle-bot_PushMaster.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: npm ci, run validate
@@ -36,7 +36,7 @@ jobs:
           cp ./package-lock.json __build__/
           git rev-list --count master > __build__/ccnt.txt
       - name: Archive Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-api
           path: functions/tickle-bot/__build__
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tc-api
           path: tc-api
       - name: Setup google auth for github actions
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
       - name: Setup gcloud Actions
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: "437.0.1"
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
bouncer, brinks, fileUpload, help-post-comment, newman, that-api-ical, that-api-webhooks, that-join, ticket-bot, and og-image.

All accept og-image have actions updated to v4. 

This PR will not trigger a deploy when merged, as there are no changes in the function's folders, only in the `.github` folders. 